### PR TITLE
Update link to CRAN on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Maxent
 Maxent is a stand-alone Java application for modelling species geographic distributions.  This open source repository allows the Maxent community to use and contribute to the Java source code for Maxent.  For further information and the current Maxent software release, please see the Maxent home page at the American Museum of Natural History:  http://biodiversityinformatics.amnh.org/open_source/maxent.
 
-If you are looking for the R package maxnet, which implements much of the functionality of the Java application, please look for "maxnet" rather than "Maxent" on GitHub (for the open source code) or on CRAN (for the R package).  Contributions to both the Java application and the R package are welcome.
+If you are looking for the R package maxnet, which implements much of the functionality of the Java application, please look for "maxnet" rather than "Maxent" on GitHub (for the open source code) or on [CRAN](https://CRAN.R-project.org/package=maxnet) (for the R package).  Contributions to both the Java application and the R package are welcome.


### PR DESCRIPTION
I wanted to add a link to the CRAN repo for folks' convenience.

I also think that there needs to be a link to the proper GitHub repo since there are quite a few implementations. Candidates for a linking:

- [lzhang10/maxent](https://github.com/lzhang10/maxent)
- [johnbaums/rmaxent](https://github.com/johnbaums/rmaxent)